### PR TITLE
ND-805: Add line that prevents display_name from being called on Wildcard

### DIFF
--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -583,6 +583,7 @@ where
 fn name_for_alias(expr: &Expr) -> Result<String> {
     match expr {
         Expr::Sort { expr, .. } => name_for_alias(expr),
+        Expr::Wildcard => Ok("*".to_string()),
         expr => expr.display_name(),
     }
 }


### PR DESCRIPTION
This PR is a tentative solution for: https://natzkalabs.atlassian.net/browse/NDB-805

There was an issue with some warnings coming from Datafusion when running some cube SELECT queries, which looked like

```
2022-11-29T16:08:18.800482Z  WARN datafusion_optimizer::optimizer: Skipping optimizer rule 'type_coercion' due to unexpected error: Internal error: Create name does n
ot support wildcard. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
2022-11-29T16:08:18.802012Z  WARN datafusion_optimizer::optimizer: Skipping optimizer rule 'unwrap_cast_in_comparison' due to unexpected error: Internal error: Create
 name does not support wildcard. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
2022-11-29T16:08:18.808211Z  WARN datafusion_optimizer::optimizer: Skipping optimizer rule 'unwrap_cast_in_comparison' due to unexpected error: Internal error: Create
 name does not support wildcard. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```
 
These warnings showed up any time some cube dimensions were not mentioned in the query, but were absent in case all dimensions featured in the query. The problem is linked to the fact that Datafusion takes care of the omitted dimensions by creating a wildcard, which is a references to all the fields in the schema and corresponds to the `*`. This in itself is not a problem, but then the `type_coercion` and `unwrap_cast_in_comparison` optimization rules call the `display_name` method on an expression which is a `Wildcard`, which is not allowed because the `create_name` method called inside `display_name` does not support `Wildcard`.

To go a bit more into detail, the `optimize_internal` methods from `type_coercion` and `unwrap_cast_in_comparison` call the `rewrite_preserving_name` function from `datafusion/optimizer/src/utils.rs`, which just rewrites an expression while keeping its name unchanged. It calls `name_for_alias`, which gets the name of an expression by calling `display_name`, which gives rise to the warnings. 

This is not a major problem as it can have no impact on query execution, as it only prevents the `type_coercion` and `unwrap_cast_in_comparison` optimization rules from being applied to the cube dimensions we are not considering anyway. Nevertheless, we can get rid of the warnings by finding a suitable workaround. The one I suggest here is just by adding a line that sets `*` as the expression name in case a `Wildcard` is found, instead of calling `display_name` on it. Perhaps there are other ways to go around it, but this one works and makes sense to me.

Once we agree on the solution, we can open an issue and a PR that solves it in Datafusion :)